### PR TITLE
Fix: update_app_data

### DIFF
--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -1,0 +1,67 @@
+CREATE OR REPLACE VIEW
+    dune_user_generated.gnosis_protocol_v2_app_data
+AS (
+    -- The following query is built on top of https://dune.xyz/queries/257782
+    with
+    partialy_parsed_app_info as (
+        SELECT
+            app_data as app_id,
+            referrer::json -> 'appCode' as app_code,
+            referrer::json -> 'version' as app_version,
+            (referrer::json -> 'metadata')::json as metadata
+        from dune_user_generated.gp_appdata
+    ),
+
+    further_parsed_app_info as (
+        select
+            app_id,
+            app_code,
+            app_version,
+            metadata -> 'environment' as environment,
+            (metadata -> 'referrer')::json as referal
+        from partialy_parsed_app_info
+    ),
+
+
+    fully_parsed_app_data as (
+        select
+            app_id,
+            app_code::text,
+            app_version::text,
+            environment::text,
+            (referal -> 'address')::text as referrer,
+            (referal -> 'version')::text as referal_version
+        from further_parsed_app_info
+    ),
+
+    -- Fetching the others.
+    trade_call_data_and_hash as (
+        SELECT
+            jsonb_array_elements(trades) as trade_call_data
+        FROM gnosis_protocol_v2."GPv2Settlement_call_settle" call
+     ),
+
+    decoded_trade_call_data_and_hash as (
+        SELECT trim( '"' from (trade_call_data->'appData')::text) as app_data
+        FROM trade_call_data_and_hash
+    ),
+
+    all_app_hashes as (
+        SELECT distinct(app_data) as app_hash
+        from decoded_trade_call_data_and_hash
+    )
+
+    SELECT
+        app_hash,
+        trim('"' from app_code) as app_code,
+        trim('"' from app_version) as app_version,
+        trim('"' from environment) as environment,
+        trim('"' from referrer) as referrer,
+        trim('"' from referal_version) as referal_version
+    FROM all_app_hashes
+    LEFT OUTER JOIN fully_parsed_app_data
+    ON app_hash = app_id
+);
+
+select * from dune_user_generated.gnosis_protocol_v2_app_data
+

--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -1,4 +1,8 @@
 CREATE OR REPLACE VIEW
+    dune_user_generated.gp_appdata (app_data, referrer)
+    AS VALUES {{VALUES}};
+
+CREATE OR REPLACE VIEW
     dune_user_generated.gnosis_protocol_v2_app_data
 AS (
     -- The following query is built on top of https://dune.xyz/queries/257782

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         raw_sql=QUERY,
         network=Network.MAINNET,
         parameters=[],
-        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "257782"))
+        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "257782")),
     )
     # App hash with referral data as json
     dune.initiate_query(app_data_query)
@@ -35,10 +35,10 @@ if __name__ == "__main__":
     parsed_app_data_query = DuneQuery(
         name="Parsed App Data Mapping",
         description="",
-        raw_sql=open_query('./dune_api_scripts/queries/parsed_app_data.sql'),
+        raw_sql=open_query("./dune_api_scripts/queries/parsed_app_data.sql"),
         network=Network.MAINNET,
         parameters=[],
-        query_id=int(getenv("QUERY_ID_PARSED_APP_DATA", "279621"))
+        query_id=int(getenv("QUERY_ID_PARSED_APP_DATA", "279621")),
     )
     # TODO - update execute_query to only need query ID and parameters.
     dune.execute_query(parsed_app_data_query)

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -3,6 +3,8 @@ from os import getenv
 
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
+from duneapi.util import open_query
+
 from .utils import app_data_entries
 
 if __name__ == "__main__":
@@ -16,10 +18,28 @@ if __name__ == "__main__":
     dune_user_generated.gp_appdata (app_data, referrer)
     AS VALUES {VALUES};"""
 
-    # update query in dune
-    query_id = int(getenv("QUERY_ID_ALL_APP_DATA", "257782"))
+    app_data_query = DuneQuery(
+        name="App Data Mapping",
+        description="",
+        raw_sql=QUERY,
+        network=Network.MAINNET,
+        parameters=[],
+        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "257782"))
+    )
+    # App hash with referral data as json
+    dune.initiate_query(app_data_query)
+    dune.execute_query(app_data_query)
+    # Check out the raw results here: https://dune.xyz/queries/257782
 
-    dune_query = DuneQuery("", "", QUERY, Network.MAINNET, [], query_id)
-    # fetch data
-    dune.execute_query(dune_query)
-    # Check out the results here: https://dune.xyz/queries/257782
+    # Parsed referral data
+    parsed_app_data_query = DuneQuery(
+        name="Parsed App Data Mapping",
+        description="",
+        raw_sql=open_query('./dune_api_scripts/queries/parsed_app_data.sql'),
+        network=Network.MAINNET,
+        parameters=[],
+        query_id=int(getenv("QUERY_ID_PARSED_APP_DATA", "279621"))
+    )
+    # TODO - update execute_query to only need query ID and parameters.
+    dune.execute_query(parsed_app_data_query)
+    # Check out the parsed results here: https://dune.xyz/queries/279621

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -12,11 +12,10 @@ if __name__ == "__main__":
     dune = DuneAPI.new_from_environment()
     VALUES = app_data_entries()
 
-    # build query
-    QUERY = f"""
-    CREATE OR REPLACE VIEW
-    dune_user_generated.gp_appdata (app_data, referrer)
-    AS VALUES {VALUES};"""
+    # build query from VALUES
+    QUERY = open_query("./dune_api_scripts/queries/parsed_app_data.sql").replace(
+        "{{VALUES}}", VALUES
+    )
 
     app_data_query = DuneQuery(
         name="App Data Mapping",
@@ -24,22 +23,9 @@ if __name__ == "__main__":
         raw_sql=QUERY,
         network=Network.MAINNET,
         parameters=[],
-        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "257782")),
+        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "863359")),
     )
     # App hash with referral data as json
     dune.initiate_query(app_data_query)
     dune.execute_query(app_data_query)
-    # Check out the raw results here: https://dune.xyz/queries/257782
-
-    # Parsed referral data
-    parsed_app_data_query = DuneQuery(
-        name="Parsed App Data Mapping",
-        description="",
-        raw_sql=open_query("./dune_api_scripts/queries/parsed_app_data.sql"),
-        network=Network.MAINNET,
-        parameters=[],
-        query_id=int(getenv("QUERY_ID_PARSED_APP_DATA", "279621")),
-    )
-    # TODO - update execute_query to only need query ID and parameters.
-    dune.execute_query(parsed_app_data_query)
-    # Check out the parsed results here: https://dune.xyz/queries/279621
+    # Check out the raw results here: https://dune.xyz/queries/863359


### PR DESCRIPTION
PR #6 introduced an undesired change that was not the original intention of the `update_app_data` script. That is, it was only executing a fixed query (without updating the values). 

In this PR we fix that, but also add a follow up query that parses the JSON content from the view into an actual table of app data.