### PR TITLE
Paresing appdata with json format v3

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -2,3 +2,4 @@ pub mod app_data_json_format;
 pub mod dune_json_formats;
 pub mod in_memory_database;
 pub mod referral_store;
+pub mod u256_decimal;

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -5,14 +5,12 @@ use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Referrer {
     pub address: H160,
     pub version: String,
 }
 
-#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Quote {
@@ -23,7 +21,6 @@ pub struct Quote {
     pub version: String,
 }
 
-#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Metadata {
     // we make all of the field optional, in order to be compatible with all versions

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -3,7 +3,6 @@
 use crate::models::u256_decimal;
 use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 pub struct Referrer {
@@ -28,7 +27,6 @@ pub struct Metadata {
     pub referrer: Option<Referrer>,
     pub quote: Option<Quote>,
 }
-#[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AppData {

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -1,6 +1,7 @@
 //! Contains the app_data file structures, as they are stored in ipfs
 //!
-use primitive_types::H160;
+use crate::models::u256_decimal;
+use primitive_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -13,17 +14,30 @@ pub struct Referrer {
 
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
-pub struct Metadata {
-    pub environment: Option<String>,
-    pub referrer: Option<Referrer>,
+#[serde(rename_all = "camelCase")]
+pub struct Quote {
+    #[serde(with = "u256_decimal")]
+    pub sell_amount: U256,
+    #[serde(with = "u256_decimal")]
+    pub buy_amount: U256,
+    pub version: String,
 }
 
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
+pub struct Metadata {
+    // we make all of the field optional, in order to be compatible with all versions
+    pub environment: Option<String>,
+    pub referrer: Option<Referrer>,
+    pub quote: Option<Quote>,
+}
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AppData {
     pub version: String,
     pub app_code: String,
+    pub environment: Option<String>,
     pub metadata: Option<Metadata>,
 }
 
@@ -42,7 +56,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_loading_json_and_reading_referral() {
+    fn test_loading_json_v1_and_reading_referral() {
         let value = json!({
                 "version":"1.2.3",
                 "appCode":"MooSwap",
@@ -59,6 +73,7 @@ mod tests {
         let expected = AppData {
             version: "1.2.3".to_string(),
             app_code: "MooSwap".to_string(),
+            environment: None,
             metadata: Some(Metadata {
                 environment: Some("production".to_string()),
                 referrer: Some(Referrer {
@@ -66,6 +81,50 @@ mod tests {
                         .parse()
                         .unwrap(),
                     version: "6.6.6".to_string(),
+                }),
+                quote: None,
+            }),
+        };
+
+        assert_eq!(json, expected);
+    }
+    #[test]
+    fn test_loading_json_v3_and_reading_referral() {
+        let value = json!({
+                "version":"1.2.3",
+                "appCode":"MooSwap",
+                "environment": "production",
+                "metadata":{
+                    "environment": "production",
+                    "referrer":{
+                        "kind":"referrer",
+                        "address":"0x8c35B7eE520277D14af5F6098835A584C337311b",
+                        "version":"6.6.6"
+                },
+                "quote": {
+                    "version": "1.0",
+                    "sellAmount": "23426235345",
+                    "buyAmount": "2341253523453",
+                }
+            }
+        });
+        let json: AppData = serde_json::from_value(value).unwrap();
+        let expected = AppData {
+            version: "1.2.3".to_string(),
+            app_code: "MooSwap".to_string(),
+            environment: Some("production".to_string()),
+            metadata: Some(Metadata {
+                environment: Some("production".to_string()),
+                referrer: Some(Referrer {
+                    address: "0x8c35B7eE520277D14af5F6098835A584C337311b"
+                        .parse()
+                        .unwrap(),
+                    version: "6.6.6".to_string(),
+                }),
+                quote: Some(Quote {
+                    version: String::from("1.0"),
+                    sell_amount: U256::from_dec_str("23426235345").unwrap(),
+                    buy_amount: U256::from_dec_str("2341253523453").unwrap(),
                 }),
             }),
         };

--- a/src/models/referral_store.rs
+++ b/src/models/referral_store.rs
@@ -65,6 +65,7 @@ mod tests {
         let entry = AppData {
             version: "1.2.3".to_string(),
             app_code: "MooSwap".to_string(),
+            environment: None,
             metadata: Some(Metadata {
                 environment: Some("production".to_string()),
                 referrer: Some(Referrer {
@@ -74,6 +75,7 @@ mod tests {
                         .unwrap(),
                     version: "6.6.6".to_string(),
                 }),
+                quote: None,
             }),
         };
 
@@ -86,12 +88,14 @@ mod tests {
             "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4":{
                  "version":"1.2.3",
                  "appCode":"MooSwap",
+                 "environment": null,
                  "metadata":{
                      "environment": "production",
                      "referrer":{
                          "address":"0x8c35b7ee520277d14af5f6098835a584c337311b",
                          "version":"6.6.6"
-                 }
+                 },
+                 "quote": null,
             }
          }
         });

--- a/src/models/referral_store.rs
+++ b/src/models/referral_store.rs
@@ -6,6 +6,7 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AppDataEntry {
     Data(Option<AppData>),

--- a/src/models/u256_decimal.rs
+++ b/src/models/u256_decimal.rs
@@ -1,30 +1,11 @@
 use primitive_types::U256;
 use serde::{de, Deserializer, Serializer};
-use serde_with::{DeserializeAs, SerializeAs};
 use std::fmt;
 
 // Code copied from here: https://github.com/cowprotocol/services/blob/main/crates/model/src/u256_decimal.rs
 // It was copied, as we prefer to not depend on such a big project.
 
 pub struct DecimalU256;
-
-impl<'de> DeserializeAs<'de, U256> for DecimalU256 {
-    fn deserialize_as<D>(deserializer: D) -> Result<U256, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserialize(deserializer)
-    }
-}
-
-impl<'de> SerializeAs<U256> for DecimalU256 {
-    fn serialize_as<S>(source: &U256, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize(source, serializer)
-    }
-}
 
 pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -76,17 +57,22 @@ pub fn format_units(amount: U256, decimals: usize) -> String {
     }
 }
 
-#[test]
-fn test_format_units() {
-    assert_eq!(format_units(1_337u64.into(), 0), "1337");
-    assert_eq!(format_units(0u64.into(), 0), "0");
-    assert_eq!(format_units(0u64.into(), 1), "0.0");
-    assert_eq!(format_units(1u64.into(), 6), "0.000001");
-    assert_eq!(format_units(999_999u64.into(), 6), "0.999999");
-    assert_eq!(format_units(1_000_000u64.into(), 6), "1.000000");
-    assert_eq!(format_units(1_337_000u64.into(), 6), "1.337000");
-    assert_eq!(
-        format_units(1_337_000_004_200u64.into(), 6),
-        "1337000.004200"
-    )
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_units() {
+        assert_eq!(format_units(1_337u64.into(), 0), "1337");
+        assert_eq!(format_units(0u64.into(), 0), "0");
+        assert_eq!(format_units(0u64.into(), 1), "0.0");
+        assert_eq!(format_units(1u64.into(), 6), "0.000001");
+        assert_eq!(format_units(999_999u64.into(), 6), "0.999999");
+        assert_eq!(format_units(1_000_000u64.into(), 6), "1.000000");
+        assert_eq!(format_units(1_337_000u64.into(), 6), "1.337000");
+        assert_eq!(
+            format_units(1_337_000_004_200u64.into(), 6),
+            "1337000.004200"
+        )
+    }
 }

--- a/src/models/u256_decimal.rs
+++ b/src/models/u256_decimal.rs
@@ -1,0 +1,92 @@
+use primitive_types::U256;
+use serde::{de, Deserializer, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+use std::fmt;
+
+// Code copied from here: https://github.com/cowprotocol/services/blob/main/crates/model/src/u256_decimal.rs
+// It was copied, as we prefer to not depend on such a big project.
+
+pub struct DecimalU256;
+
+impl<'de> DeserializeAs<'de, U256> for DecimalU256 {
+    fn deserialize_as<D>(deserializer: D) -> Result<U256, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+    }
+}
+
+impl<'de> SerializeAs<U256> for DecimalU256 {
+    fn serialize_as<S>(source: &U256, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(source, serializer)
+    }
+}
+
+pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor {}
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = U256;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a u256 encoded as a decimal encoded string")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            U256::from_dec_str(s).map_err(|err| {
+                de::Error::custom(format!("failed to decode {:?} as decimal u256: {}", s, err))
+            })
+        }
+    }
+
+    deserializer.deserialize_str(Visitor {})
+}
+
+/// Converts an amount of units of an ERC20 token with the specified amount of
+/// decimals into its decimal representation as a string.
+///
+pub fn format_units(amount: U256, decimals: usize) -> String {
+    let str_amount = amount.to_string();
+    if decimals == 0 {
+        str_amount
+    } else if str_amount.len() <= decimals {
+        format!("0.{:0>pad_left$}", str_amount, pad_left = decimals)
+    } else {
+        format!(
+            "{}.{}",
+            &str_amount[0..str_amount.len() - decimals],
+            &str_amount[str_amount.len() - decimals..]
+        )
+    }
+}
+
+#[test]
+fn test_format_units() {
+    assert_eq!(format_units(1_337u64.into(), 0), "1337");
+    assert_eq!(format_units(0u64.into(), 0), "0");
+    assert_eq!(format_units(0u64.into(), 1), "0.0");
+    assert_eq!(format_units(1u64.into(), 6), "0.000001");
+    assert_eq!(format_units(999_999u64.into(), 6), "0.999999");
+    assert_eq!(format_units(1_000_000u64.into(), 6), "1.000000");
+    assert_eq!(format_units(1_337_000u64.into(), 6), "1.337000");
+    assert_eq!(
+        format_units(1_337_000_004_200u64.into(), 6),
+        "1337000.004200"
+    )
+}

--- a/src/referral_maintenance.rs
+++ b/src/referral_maintenance.rs
@@ -291,6 +291,7 @@ mod tests {
         let expected = AppData {
             version: "0.1.0".to_string(),
             app_code: "CowSwap".to_string(),
+            environment: None,
             metadata: Some(Metadata {
                 environment: None,
                 referrer: Some(Referrer {
@@ -299,6 +300,7 @@ mod tests {
                         .unwrap(),
                     version: "0.1.0".to_string(),
                 }),
+                quote: None,
             }),
         };
         assert_eq!(referral, expected);


### PR DESCRIPTION
A new [app_data version was introduced](https://docs.google.com/document/d/1jsP8ie7IlzmqxmBiVpoHcz5ftOEyjv4vbAvJ8mO0X1U/edit), in order to have the quotes stored in the order metadata.

By not going strictly with the new version, but having just some optional fields, we are able to be compatible with all version, without version specific parsing.

Later on, we can introduce a json parsing depending on the different version - maybe with [this lib](https://jsontypedef.com/docs/rust-codegen/). But I think this complexity is not yet needed.

Testplan:

Use the following distinct_app_data.json:
```
{
    "app_data": [
        {
            "appdata": "\"0xcb29f9a9c4a32b88f860b55af807040732d8c3730e400648a208c06d63695b97\""
        },
        {
            "appdata": "\"0x0124a4fd6b0d94dcb40bc25b6b41c86f3136f2e4139c6f179d5b8eb99364dd38\""
        }
    ],
    "time_of_download": 1653892135
}
```
in ./data/app_data. The first app_data has the version 1 and the other has the verison 3. Version 2 test is not needed, as this version was never live and [no order was ever created with it](https://logs.cow.fi/goto/944c7850-f39c-11ec-97dd-b383b91e99a0)

And then run:
```
cargo run -- --retrys-for-ipfs-file-fetching=3 
```
and you can inspect the newly created file app_data_referral_relationship for the downloaded data. 
