### PR TITLE
AppData V4 & Quote V2

### DIFF
--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -10,14 +10,30 @@ pub struct Referrer {
     pub version: String,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[serde(untagged)]
+pub enum Quote {
+    V1(QuoteV1),
+    V2(QuoteV2),
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
-pub struct Quote {
+pub struct QuoteV1 {
     #[serde(with = "u256_decimal")]
     pub sell_amount: U256,
     #[serde(with = "u256_decimal")]
     pub buy_amount: U256,
     pub version: String,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteV2 {
+    pub version: String,
+    // This value does not need a large uint type
+    #[serde(with = "serde_with::rust::display_fromstr")]
+    pub slippage_bips: u32,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
@@ -27,6 +43,7 @@ pub struct Metadata {
     pub referrer: Option<Referrer>,
     pub quote: Option<Quote>,
 }
+
 #[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AppData {
@@ -116,14 +133,130 @@ mod tests {
                         .unwrap(),
                     version: "6.6.6".to_string(),
                 }),
-                quote: Some(Quote {
+                quote: Some(Quote::V1(QuoteV1{
                     version: String::from("1.0"),
                     sell_amount: U256::from_dec_str("23426235345").unwrap(),
                     buy_amount: U256::from_dec_str("2341253523453").unwrap(),
-                }),
+                })),
             }),
         };
 
         assert_eq!(json, expected);
+    }
+    #[test]
+    fn test_loading_json_v4_with_slippage() {
+        let value = json!({
+                "version":"1.2.3",
+                "appCode":"MooSwap",
+                "environment": "production",
+                "metadata":{
+                    "environment": "production",
+                    "referrer":{
+                        "kind":"referrer",
+                        "address":"0x8c35B7eE520277D14af5F6098835A584C337311b",
+                        "version":"6.6.6"
+                },
+                "quote": {
+                    "version": "2.0",
+                    "slippageBips": "5"
+                }
+            }
+        });
+        let json: AppData = serde_json::from_value(value).unwrap();
+        let expected = AppData {
+            version: "1.2.3".to_string(),
+            app_code: "MooSwap".to_string(),
+            environment: Some("production".to_string()),
+            metadata: Some(Metadata {
+                environment: Some("production".to_string()),
+                referrer: Some(Referrer {
+                    address: "0x8c35B7eE520277D14af5F6098835A584C337311b"
+                        .parse()
+                        .unwrap(),
+                    version: "6.6.6".to_string(),
+                }),
+                quote: Some(Quote::V2(QuoteV2{
+                    version: String::from("2.0"),
+                    slippage_bips: 5,
+                })),
+            }),
+        };
+
+        assert_eq!(json, expected);
+    }
+    #[test]
+    fn test_loading_json_v4_with_amounts() {
+        let value = json!({
+                "version":"1.2.3",
+                "appCode":"MooSwap",
+                "environment": "production",
+                "metadata":{
+                    "environment": "production",
+                    "referrer":{
+                        "kind":"referrer",
+                        "address":"0x8c35B7eE520277D14af5F6098835A584C337311b",
+                        "version":"6.6.6"
+                },
+                "quote": {
+                    "version": "2.0",
+                    "buyAmount": "123456789",
+                    "sellAmount": "123456789101112",
+                }
+            }
+        });
+        let json: AppData = serde_json::from_value(value).unwrap();
+        let expected = AppData {
+            version: "1.2.3".to_string(),
+            app_code: "MooSwap".to_string(),
+            environment: Some("production".to_string()),
+            metadata: Some(Metadata {
+                environment: Some("production".to_string()),
+                referrer: Some(Referrer {
+                    address: "0x8c35B7eE520277D14af5F6098835A584C337311b"
+                        .parse()
+                        .unwrap(),
+                    version: "6.6.6".to_string(),
+                }),
+                // Notice that although we have specified v2 for quote, we fall back on the v1 quote.
+                // This is much cleaner than trying to implement optional fields for each of
+                // the three components and validate that
+                // only one of slippage OR (both of sell/buy amounts are populated)
+                quote: Some(Quote::V1(QuoteV1{
+                    version: String::from("2.0"),
+                    buy_amount: U256::from_dec_str("123456789").unwrap(),
+                    sell_amount: U256::from_dec_str("123456789101112").unwrap(),
+                })),
+            }),
+        };
+
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn test_loading_quote() {
+        let v1_value = json!({
+            "version": "2.0",
+            "sellAmount": "123",
+            "buyAmount": "4567",
+        });
+        let v2_value = json!({
+            "version": "2.0",
+            "slippageBips": "100"
+        });
+        let json_1: Quote = serde_json::from_value(v1_value).unwrap();
+        let json_2: Quote = serde_json::from_value(v2_value).unwrap();
+        let expected_1 = Quote::V1(QuoteV1 {
+            version: String::from("2.0"),
+            sell_amount: U256::from_dec_str("123").unwrap(),
+            buy_amount: U256::from_dec_str("4567").unwrap(),
+        });
+
+        let expected_2 = Quote::V2(QuoteV2 {
+            version: String::from("2.0"),
+            slippage_bips: 100,
+        });
+
+        assert_eq!(json_1, expected_1);
+        assert_eq!(json_2, expected_2);
     }
 }

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -133,7 +133,7 @@ mod tests {
                         .unwrap(),
                     version: "6.6.6".to_string(),
                 }),
-                quote: Some(Quote::V1(QuoteV1{
+                quote: Some(Quote::V1(QuoteV1 {
                     version: String::from("1.0"),
                     sell_amount: U256::from_dec_str("23426235345").unwrap(),
                     buy_amount: U256::from_dec_str("2341253523453").unwrap(),
@@ -175,7 +175,7 @@ mod tests {
                         .unwrap(),
                     version: "6.6.6".to_string(),
                 }),
-                quote: Some(Quote::V2(QuoteV2{
+                quote: Some(Quote::V2(QuoteV2 {
                     version: String::from("2.0"),
                     slippage_bips: 5,
                 })),
@@ -221,7 +221,7 @@ mod tests {
                 // This is much cleaner than trying to implement optional fields for each of
                 // the three components and validate that
                 // only one of slippage OR (both of sell/buy amounts are populated)
-                quote: Some(Quote::V1(QuoteV1{
+                quote: Some(Quote::V1(QuoteV1 {
                     version: String::from("2.0"),
                     buy_amount: U256::from_dec_str("123456789").unwrap(),
                     sell_amount: U256::from_dec_str("123456789101112").unwrap(),


### PR DESCRIPTION
This change really is only for the version bump of Quote to Quote V2.

We take the approach suggested here https://github.com/cowprotocol/dune-bridge/pull/11/files#r905932280

Note that there was an option to include buy and sell amounts in the v2 struct, but then all of buy, sell and slippage would have to be optional and then additional messy validation would need to be done during deserialization. Instead we take the approach without needing any Optional fields where v1 contains the the old version with buy and sell amounts both neing not optional. There is no constraint on the version number for either type, so when serializing both types are accepted and all wind up being a Quote anyway. This is carefully noted in this test itself.

Thanks to @MartinquaXD for reminding me how to rust.

In this particular case, I am not actually sure why appData version needed to be bumped.


## Test Plan: 
New unit tests.