### PR TITLE
Fix Quote Parsing

### DIFF
--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn test_loading_quote() {
+    fn test_loading_quote_ok() {
         let v1_value = json!({
             "version": "0.1.0",
             "sellAmount": "123",
@@ -203,5 +203,40 @@ mod tests {
 
         assert_eq!(json_1, expected_1);
         assert_eq!(json_2, expected_2);
+    }
+
+    #[test]
+    fn test_loading_quote_err() {
+        // V2 version with V1 data
+        assert_eq!(
+            serde_json::from_value::<Quote>(json!({
+                "version": "0.2.0",
+                "sellAmount": "123",
+                "buyAmount": "4567",
+            }))
+            .unwrap_err()
+            .to_string(),
+            "missing field `slippageBips`"
+        );
+        // V1 version with V2 data
+        assert_eq!(
+            serde_json::from_value::<Quote>(json!({
+                "version": "0.1.0",
+                "slippageBips": "100"
+            }))
+            .unwrap_err()
+            .to_string(),
+            "missing field `sellAmount`"
+        );
+        // Invalid Version Data
+        assert_eq!(
+            serde_json::from_value::<Quote>(json!({
+                "version": "invalid version",
+                "slippageBips": "100"
+            }))
+            .unwrap_err()
+            .to_string(),
+            "unknown variant `invalid version`, expected `0.1.0` or `0.2.0`"
+        );
     }
 }


### PR DESCRIPTION
According to the lengthy discussion had on #12 it was concluded that the most practical versioning for Quotes was the eliminate the possibility of including QuoteV1 type data in QuoteV2. This change is still pending implementation to the spec (a request made to the front end team). Follow the progress in [slack](https://cowservices.slack.com/archives/C0361CCTFD5/p1656930173488469?thread_ts=1655804727.508909&cid=C0361CCTFD5)


Working from App Data Schema (but pending changes)

- [Google Doc](https://docs.google.com/document/d/1jsP8ie7IlzmqxmBiVpoHcz5ftOEyjv4vbAvJ8mO0X1U/edit#heading=h.sr5n3skyy4a0)