### PR TITLE
Update Dune AppData

### DIFF
--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -22,7 +22,8 @@ AS (
             app_code,
             app_version,
             metadata -> 'environment' as environment,
-            (metadata -> 'referrer')::json as referal
+            (metadata -> 'referrer')::json as referal,
+            (metadata -> 'quote')::json as quote
         from partialy_parsed_app_info
     ),
 
@@ -34,7 +35,8 @@ AS (
             app_version::text,
             environment::text,
             (referal -> 'address')::text as referrer,
-            (referal -> 'version')::text as referal_version
+            (referal -> 'version')::text as referal_version,
+            (quote -> 'slippageBips')::text as slippage
         from further_parsed_app_info
     ),
 
@@ -61,7 +63,8 @@ AS (
         trim('"' from app_version) as app_version,
         trim('"' from environment) as environment,
         trim('"' from referrer) as referrer,
-        trim('"' from referal_version) as referal_version
+        trim('"' from referal_version) as referal_version,
+        trim('"' from slippage) as slippage
     FROM all_app_hashes
     LEFT OUTER JOIN fully_parsed_app_data
     ON app_hash = app_id

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -36,6 +36,8 @@ if __name__ == "__main__":
         # This is an issue with error handling on duneapi side:
         # https://github.com/bh2smith/duneapi/issues/48
         print("Failed likely due to dune login credentials", err)
-    except Exception as err:
+    except Exception as err:  # pylint:disable=broad-except
+        # TODO - this is only temporary till we can fix the above exception handling...
+        #  Essentially, we allow failure so not to disturb the processes.
         print("Unhandled exception", err)
     # Check out the raw results here: https://dune.xyz/queries/863359

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -25,11 +25,17 @@ if __name__ == "__main__":
         parameters=[],
         query_id=query_id,
     )
-    print(app_data_query)
     # App hash with referral data as json
-    x = dune.initiate_query(app_data_query)
-    y = dune.execute_query(app_data_query)
-    print(y)
-    print(f"Successfully updated app data view at https://dune.xyz/queries/{query_id}")
-
+    try:
+        dune.initiate_query(app_data_query)
+        dune.execute_query(app_data_query)
+        print(
+            f"app data successfully updated at https://dune.xyz/queries/{query_id}"
+        )
+    except SystemExit as err:
+        # This is an issue with error handling on duneapi side:
+        # https://github.com/bh2smith/duneapi/issues/48
+        print("Failed likely due to dune login credentials", err)
+    except Exception as err:
+        print("Unhandled exception", err)
     # Check out the raw results here: https://dune.xyz/queries/863359

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -16,16 +16,20 @@ if __name__ == "__main__":
     QUERY = open_query("./dune_api_scripts/queries/parsed_app_data.sql").replace(
         "{{VALUES}}", VALUES
     )
-
+    query_id = int(getenv("QUERY_ID_ALL_APP_DATA", "863359"))
     app_data_query = DuneQuery(
         name="App Data Mapping",
         description="",
         raw_sql=QUERY,
         network=Network.MAINNET,
         parameters=[],
-        query_id=int(getenv("QUERY_ID_ALL_APP_DATA", "863359")),
+        query_id=query_id,
     )
     # App hash with referral data as json
-    dune.initiate_query(app_data_query)
-    dune.execute_query(app_data_query)
+    try:
+        dune.initiate_query(app_data_query)
+        dune.execute_query(app_data_query)
+        print(f"Successfully updated app data view at https://dune.xyz/queries/{query_id}")
+    except Exception as e:
+        print(e)
     # Check out the raw results here: https://dune.xyz/queries/863359

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -25,11 +25,11 @@ if __name__ == "__main__":
         parameters=[],
         query_id=query_id,
     )
+    print(app_data_query)
     # App hash with referral data as json
-    try:
-        dune.initiate_query(app_data_query)
-        dune.execute_query(app_data_query)
-        print(f"Successfully updated app data view at https://dune.xyz/queries/{query_id}")
-    except Exception as e:
-        print(e)
+    x = dune.initiate_query(app_data_query)
+    y = dune.execute_query(app_data_query)
+    print(y)
+    print(f"Successfully updated app data view at https://dune.xyz/queries/{query_id}")
+
     # Check out the raw results here: https://dune.xyz/queries/863359

--- a/src/in_memory_maintenance.rs
+++ b/src/in_memory_maintenance.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(3);
 
-pub async fn in_memory_database_maintaince(
+pub async fn in_memory_database_maintenance(
     memory_database: Arc<InMemoryDatabase>,
     dune_download_folder: String,
     health: Arc<HttpHealthEndpoint>,

--- a/src/in_memory_maintenance.rs
+++ b/src/in_memory_maintenance.rs
@@ -25,7 +25,7 @@ pub async fn in_memory_database_maintenance(
                 }
                 Err(err) => match format!("{:?}", err).contains("EOF while parsing") {
                     true => {
-                        // Sometimes unexpected EOF error messages are thrown, if the reading of rust is faster than the writting of the python scripts. Since this is expected, we don't error.
+                        // Sometimes unexpected EOF error messages are thrown, if the reading of rust is faster than the writing of the python scripts. Since this is expected, we don't error.
                         tracing::debug!("Could not read the dune data, due to error: {:?}, most likely this is due to an running writing operation on the file", err)
                     }
                     false => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use gpdata::health::HttpHealthEndpoint;
-use gpdata::in_memory_maintenance::in_memory_database_maintaince;
+use gpdata::in_memory_maintenance::in_memory_database_maintenance;
 use gpdata::models::in_memory_database::DatabaseStruct;
 use gpdata::models::in_memory_database::InMemoryDatabase;
 use gpdata::models::referral_store::ContentStore;
@@ -39,7 +39,7 @@ async fn main() {
     let memory_database = Arc::new(InMemoryDatabase(Mutex::new(DatabaseStruct::default())));
     let health = Arc::new(HttpHealthEndpoint::new());
     let serve_task = serve_task(memory_database.clone(), args.bind_address, health.clone());
-    let maintenance_task = tokio::task::spawn(in_memory_database_maintaince(
+    let maintenance_task = tokio::task::spawn(in_memory_database_maintenance(
         memory_database.clone(),
         dune_download_folder.clone(),
         health,

--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -208,35 +208,23 @@ mod tests {
     #[test]
     fn test_loading_quote_err() {
         // V2 version with V1 data
-        assert_eq!(
-            serde_json::from_value::<Quote>(json!({
-                "version": "0.2.0",
-                "sellAmount": "123",
-                "buyAmount": "4567",
-            }))
-            .unwrap_err()
-            .to_string(),
-            "missing field `slippageBips`"
-        );
+        assert!(serde_json::from_value::<Quote>(json!({
+            "version": "0.2.0",
+            "sellAmount": "123",
+            "buyAmount": "4567",
+        }))
+        .is_err());
         // V1 version with V2 data
-        assert_eq!(
-            serde_json::from_value::<Quote>(json!({
-                "version": "0.1.0",
-                "slippageBips": "100"
-            }))
-            .unwrap_err()
-            .to_string(),
-            "missing field `sellAmount`"
-        );
+        assert!(serde_json::from_value::<Quote>(json!({
+            "version": "0.1.0",
+            "slippageBips": "100"
+        }))
+        .is_err());
         // Invalid Version Data
-        assert_eq!(
-            serde_json::from_value::<Quote>(json!({
-                "version": "invalid version",
-                "slippageBips": "100"
-            }))
-            .unwrap_err()
-            .to_string(),
-            "unknown variant `invalid version`, expected `0.1.0` or `0.2.0`"
-        );
+        assert!(serde_json::from_value::<Quote>(json!({
+            "version": "invalid version",
+            "slippageBips": "100"
+        }))
+        .is_err());
     }
 }


### PR DESCRIPTION
This PR updates the Query the populate app data view with the new quote slippage value.

We also fix the error handling and log success (so we can see if this is working in the kubernetes pods).

A follow up PR will update the staging environment to run this script every 30 minutes as part of an already existing cron job.

Here is the corresponding staging PR (changes have already been applied): https://gitlab.gnosisdev.com/devops/aws/aws-infra-staging/k8s-team-namespaces/gnosis-staging-k8s-gp/-/merge_requests/402


# Test Plan

To run this with the valid user credentials (for josojo)

```sh
python -m dune_api_scripts.update_appdata_view
```