### PR TITLE
Serve Solver List I: Fetch & Store

### DIFF
--- a/dune_api_scripts/constants.py
+++ b/dune_api_scripts/constants.py
@@ -1,0 +1,7 @@
+"""A collection of global constants for the project."""
+from duneapi.types import Network
+
+NETWORK_SHORT_NAMES = {
+    Network.MAINNET: "mainnet",
+    Network.GCHAIN: "gc",
+}

--- a/dune_api_scripts/requirements.txt
+++ b/dune_api_scripts/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.27.1
 pylint==2.11.1
 pytest==6.2.5
-duneapi==3.0.3
+duneapi==3.0.7
 python-dotenv==0.20.0
 

--- a/dune_api_scripts/store/solver_list.py
+++ b/dune_api_scripts/store/solver_list.py
@@ -1,15 +1,11 @@
 """Modifies and executed dune query for today's data"""
 from __future__ import annotations
 
-import dataclasses
 import json
 import os
-from dataclasses import dataclass
-from typing import Any
 
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
-from duneapi.types import Address
 
 
 SOLVER_QUERY = """

--- a/dune_api_scripts/store/solver_list.py
+++ b/dune_api_scripts/store/solver_list.py
@@ -38,6 +38,7 @@ class Solver:
 
 def store_solver_list(dune: DuneAPI) -> list[Solver]:
     # TODO - fetch for both networks and merge JSON content with chainID
+    # Waiting on https://github.com/duneanalytics/abstractions/pull/1268q
     raw_solver_list = dune.fetch(
         DuneQuery.from_environment(
             name="Solver List",

--- a/dune_api_scripts/store/solver_list.py
+++ b/dune_api_scripts/store/solver_list.py
@@ -1,0 +1,61 @@
+"""Modifies and executed dune query for today's data"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from duneapi.api import DuneAPI
+from duneapi.types import DuneQuery, Network
+from duneapi.types import Address
+
+
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        return super().default(o)
+
+
+@dataclass
+class Solver:
+    address: str
+    environment: str
+    name: str
+    active: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Solver:
+        return cls(
+            address=Address(data["address"]).address,
+            environment=data["environment"],
+            name=data["name"],
+            active=data["active"],
+        )
+
+
+def store_solver_list(dune: DuneAPI) -> list[Solver]:
+    # TODO - fetch for both networks and merge JSON content with chainID
+    raw_solver_list = dune.fetch(
+        DuneQuery.from_environment(
+            name="Solver List",
+            description="",
+            raw_sql="select * from gnosis_protocol_v2.view_solvers",
+            network=Network.MAINNET,
+            parameters=[],
+        )
+    )
+    solver_list = [Solver.from_dict(rec) for rec in raw_solver_list]
+
+    filename = os.path.join(os.environ["DUNE_DATA_FOLDER"], "solvers.json")
+    with open(filename, "w+", encoding="utf-8") as f:
+        json.dump(solver_list, f, ensure_ascii=False, indent=4, cls=EnhancedJSONEncoder)
+
+    return solver_list
+
+
+if __name__ == "__main__":
+
+    store_solver_list(dune=DuneAPI.new_from_environment())

--- a/dune_api_scripts/store/solver_list.py
+++ b/dune_api_scripts/store/solver_list.py
@@ -38,7 +38,7 @@ class Solver:
 
 def store_solver_list(dune: DuneAPI) -> list[Solver]:
     # TODO - fetch for both networks and merge JSON content with chainID
-    # Waiting on https://github.com/duneanalytics/abstractions/pull/1268q
+    # Waiting on https://github.com/duneanalytics/abstractions/pull/1268
     raw_solver_list = dune.fetch(
         DuneQuery.from_environment(
             name="Solver List",

--- a/dune_api_scripts/store/solver_list.py
+++ b/dune_api_scripts/store/solver_list.py
@@ -7,6 +7,7 @@ import os
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
 
+from dune_api_scripts.constants import NETWORK_SHORT_NAMES as SHORT_NAMES
 
 SOLVER_QUERY = """
 select 
@@ -16,11 +17,6 @@ select
     active
 from gnosis_protocol_v2.view_solvers
 """
-
-SHORT_NAMES = {
-    Network.MAINNET: "mainnet",
-    Network.GCHAIN: "gc",
-}
 
 
 def store_solver_list(dune: DuneAPI, network: Network) -> list[dict[str, str]]:
@@ -38,6 +34,7 @@ def store_solver_list(dune: DuneAPI, network: Network) -> list[dict[str, str]]:
     )
     with open(filename, "w+", encoding="utf-8") as f:
         json.dump(solver_list, f, ensure_ascii=False, indent=4)
+    print(f"solver list written to {filename}")
     return solver_list
 
 


### PR DESCRIPTION
As part of an effort to make our solver list universally accessible via our own API service. This is the service that would periodically fetch the most recent solver list and store it as a json file.

As a second step, we would add a route to the API (here in this project) which serves the JSON content.


Pending the existence of `view_solvers`table for Gnosis Chain (PR - [here](https://github.com/duneanalytics/abstractions/pull/1268)) we would like to store an additional field "chainID" in the json file and merge the solver lists from all networks. Alternatively we could store two separate files. Not sure which is preferred (cc @alfetopito)