### PR TITLE
[HotFix] App Content Parsing

### DIFF
--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -18,9 +18,9 @@ AS (
             referrer::json -> 'environment' as backend_env,
             (referrer::json -> 'metadata')::json -> 'environment' as meta_env,
             ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'address' as referrer,
-            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referral_version,
+            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referrer_version,
             ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'version' as quote_version,
-            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage
+            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage_bips
         from dune_user_generated.gp_appdata
     ),
 
@@ -39,9 +39,9 @@ AS (
                 else trim('"' from backend_env::text)
             end as backend_env,
             trim('"' from referrer::text) as referrer,
-            trim('"' from referral_version::text) as referral_version,
+            trim('"' from referrer_version::text) as referrer_version,
             trim('"' from quote_version::text) as quote_version,
-            trim('"' from slippage::text) as slippage
+            trim('"' from slippage_bips::text) as slippage_bips
         from partialy_parsed_app_info
     ),
 
@@ -69,8 +69,8 @@ AS (
         backend_env,
         meta_env,
         referrer,
-        referral_version,
-        slippage::int
+        referrer_version,
+        slippage_bips::int
     FROM all_app_hashes
     LEFT OUTER JOIN fully_parsed_app_data
     ON app_hash = app_id


### PR DESCRIPTION
This PR addresses 2 problems with the current query:

1. We were seeing that null valued environments were being parsed as the text "null". To see this, create a query 

```sql
select count(*) from dune_user_generated.gnosis_protocol_v2_app_data
where environment = 'null'
```

2. Also were seeing non-uniqueness (because we previously didn't include all the fields). For example:
```sql
select * from dune_user_generated.gnosis_protocol_v2_app_data
where app_hash in (
    '0x7aaf97865c2aa7f17a380f6bd566377d4336ddc785768acd431ab7ceddffc45a',
    '0x7e4b2a44ca9e43f582ac9dadb7c23a7e34f9423312066d85325e2aed4378167b'
)
```
The results here look like they should be the same... (i.e. have the same hash). However this query shows the difference in `environment` (the outer one):

```sql
select * from dune_user_generated.gp_appdata
where app_data in (
    '0x7aaf97865c2aa7f17a380f6bd566377d4336ddc785768acd431ab7ceddffc45a',
    '0x7e4b2a44ca9e43f582ac9dadb7c23a7e34f9423312066d85325e2aed4378167b'
)
```
Furthermore we add the `DROP VIEW ... CASCADE` so that we can alter the table columns


### Test Plan:
POC Query here: https://dune.com/queries/1031950


