### PR TITLE
Multi Env App Data Update

### DIFF
--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -18,9 +18,9 @@ AS (
             referrer::json -> 'environment' as backend_env,
             (referrer::json -> 'metadata')::json -> 'environment' as meta_env,
             ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'address' as referrer,
-            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referral_version,
+            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referrer_version,
             ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'version' as quote_version,
-            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage
+            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage_bips
         from dune_user_generated.gp_appdata
     ),
 
@@ -39,9 +39,9 @@ AS (
                 else trim('"' from backend_env::text)
             end as backend_env,
             trim('"' from referrer::text) as referrer,
-            trim('"' from referral_version::text) as referral_version,
+            trim('"' from referrer_version::text) as referrer_version,
             trim('"' from quote_version::text) as quote_version,
-            trim('"' from slippage::text) as slippage
+            trim('"' from slippage_bips::text) as slippage_bips
         from partialy_parsed_app_info
     ),
 
@@ -69,8 +69,8 @@ AS (
         backend_env,
         meta_env,
         referrer,
-        referral_version,
-        slippage::int
+        referrer_version,
+        slippage_bips::int
     FROM all_app_hashes
     LEFT OUTER JOIN fully_parsed_app_data
     ON app_hash = app_id

--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -16,7 +16,7 @@ AS (
             ((content::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referrer_version,
             ((content::json -> 'metadata')::json -> 'quote')::json -> 'version' as quote_version,
             ((content::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage_bips
-        from dune_user_generated.cow_protocol_raw_app_data
+        from dune_user_generated.cow_protocol_raw_app_data_{{Environment}}
     ),
 
     fully_parsed_app_data as (

--- a/dune_api_scripts/queries/parsed_app_data.sql
+++ b/dune_api_scripts/queries/parsed_app_data.sql
@@ -1,27 +1,22 @@
 CREATE OR REPLACE VIEW
-    dune_user_generated.gp_appdata (app_data, referrer)
-    AS VALUES {{VALUES}};
-
-DROP VIEW dune_user_generated.gnosis_protocol_v2_app_data CASCADE;
-CREATE OR REPLACE VIEW
-    dune_user_generated.gnosis_protocol_v2_app_data
+    dune_user_generated.cow_protocol_app_data_{{Environment}}
 AS (
     -- The following query is built on top of https://dune.xyz/queries/257782
     with
     partialy_parsed_app_info as (
         SELECT
-            app_data as app_id,
-            referrer::json -> 'appCode' as app_code,
-            referrer::json -> 'version' as app_version,
+            hash as app_id,
+            content::json -> 'appCode' as app_code,
+            content::json -> 'version' as app_version,
             -- Notice there are 2 different environment fields.
             -- One of them being utilized more than the other
-            referrer::json -> 'environment' as backend_env,
-            (referrer::json -> 'metadata')::json -> 'environment' as meta_env,
-            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'address' as referrer,
-            ((referrer::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referrer_version,
-            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'version' as quote_version,
-            ((referrer::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage_bips
-        from dune_user_generated.gp_appdata
+            content::json -> 'environment' as backend_env,
+            (content::json -> 'metadata')::json -> 'environment' as meta_env,
+            ((content::json -> 'metadata')::json -> 'referrer')::json -> 'address' as referrer,
+            ((content::json -> 'metadata')::json -> 'referrer')::json -> 'version' as referrer_version,
+            ((content::json -> 'metadata')::json -> 'quote')::json -> 'version' as quote_version,
+            ((content::json -> 'metadata')::json -> 'quote')::json -> 'slippageBips' as slippage_bips
+        from dune_user_generated.cow_protocol_raw_app_data
     ),
 
     fully_parsed_app_data as (
@@ -76,4 +71,4 @@ AS (
     ON app_hash = app_id
 );
 
-select * from dune_user_generated.gnosis_protocol_v2_app_data
+select * from dune_user_generated.cow_protocol_app_data_{{Environment}}

--- a/dune_api_scripts/queries/raw_app_data.sql
+++ b/dune_api_scripts/queries/raw_app_data.sql
@@ -1,3 +1,3 @@
 CREATE OR REPLACE VIEW
-    dune_user_generated.cow_protocol_raw_app_data (hash, content)
+    dune_user_generated.cow_protocol_raw_app_data_{{Environment}} (hash, content)
 AS VALUES {{VALUES}};

--- a/dune_api_scripts/queries/raw_app_data.sql
+++ b/dune_api_scripts/queries/raw_app_data.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE VIEW
+    dune_user_generated.cow_protocol_raw_app_data (hash, content)
+AS VALUES {{VALUES}};

--- a/dune_api_scripts/requirements.txt
+++ b/dune_api_scripts/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.27.1
 pylint==2.11.1
 pytest==6.2.5
-duneapi==3.0.3
+duneapi==3.0.10
 python-dotenv==0.20.0
 

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -1,43 +1,72 @@
 """Modifies and executed dune query for today's data"""
+import argparse
+from enum import Enum
 from os import getenv
 
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, Network
+from duneapi.types import DuneQuery, Network, QueryParameter
 from duneapi.util import open_query
 
 from .utils import app_data_entries
 
-if __name__ == "__main__":
-    # initialize the environment
-    dune = DuneAPI.new_from_environment()
-    VALUES = app_data_entries()
 
-    # build query from VALUES
-    QUERY = open_query("./dune_api_scripts/queries/parsed_app_data.sql").replace(
-        "{{VALUES}}", VALUES
+def refresh(dune: DuneAPI, query: DuneQuery):
+    dune.initiate_query(query)
+    job_id = dune.execute_query(query)
+    dune.get_results(job_id)
+    print(
+        f"{query.name} successfully updated: https://dune.xyz/queries/{query.query_id}"
     )
-    query_id = int(getenv("QUERY_ID_ALL_APP_DATA", "863359"))
-    app_data_query = DuneQuery(
-        name="App Data Mapping",
+
+
+def update_raw_app_data(dune: DuneAPI):
+    values = app_data_entries()
+    query_id = int(getenv("QUERY_ID_RAW_APP_DATA"))
+    query = DuneQuery(
+        name="Raw App Data Mapping",
         description="",
-        raw_sql=QUERY,
+        raw_sql=open_query("./dune_api_scripts/queries/raw_app_data.sql").replace(
+            "{{VALUES}}", values
+        ),
         network=Network.MAINNET,
         parameters=[],
         query_id=query_id,
     )
-    # App hash with referral data as json
+    refresh(dune, query)
+
+
+class Environment(Enum):
+    staging = "barn"
+    production = "prod"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def update_parsed_app_data(dune: DuneAPI, env: Environment):
+    query_id = int(getenv("QUERY_ID_PARSED_APP_DATA"))
+    query = DuneQuery(
+        name="Parsed App Data",
+        description="",
+        raw_sql=open_query("./dune_api_scripts/queries/parsed_app_data.sql"),
+        network=Network.MAINNET,
+        parameters=[
+            QueryParameter.enum_type("Environment", env.value, ["barn", "prod"])
+        ],
+        query_id=query_id,
+    )
+    refresh(dune, query)
+
+
+if __name__ == "__main__":
+    dune_connection = DuneAPI.new_from_environment()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--environment", type=Environment, choices=list(Environment), required=True
+    )
+    args = parser.parse_args()
     try:
-        dune.initiate_query(app_data_query)
-        dune.execute_query(app_data_query)
-        print(
-            f"app data successfully updated at https://dune.xyz/queries/{query_id}"
-        )
-    except SystemExit as err:
-        # This is an issue with error handling on duneapi side:
-        # https://github.com/bh2smith/duneapi/issues/48
-        print("Failed likely due to dune login credentials", err)
-    except Exception as err:  # pylint:disable=broad-except
-        # TODO - this is only temporary till we can fix the above exception handling...
-        #  Essentially, we allow failure so not to disturb the processes.
-        print("Unhandled exception", err)
-    # Check out the raw results here: https://dune.xyz/queries/863359
+        update_raw_app_data(dune_connection)
+        update_parsed_app_data(dune_connection, args.environment)
+    except RuntimeError as err:
+        print("Failed to update due to", err)

--- a/dune_api_scripts/update_appdata_view.py
+++ b/dune_api_scripts/update_appdata_view.py
@@ -11,6 +11,7 @@ from .utils import app_data_entries
 
 
 def refresh(dune: DuneAPI, query: DuneQuery):
+    """Updates and executes `query`"""
     dune.initiate_query(query)
     job_id = dune.execute_query(query)
     dune.get_results(job_id)
@@ -20,8 +21,9 @@ def refresh(dune: DuneAPI, query: DuneQuery):
 
 
 def update_raw_app_data(dune: DuneAPI):
+    """Updates the RAW App Data View"""
     values = app_data_entries()
-    query_id = int(getenv("QUERY_ID_RAW_APP_DATA"))
+    query_id = int(getenv("QUERY_ID_RAW_APP_DATA", "1032460"))
     query = DuneQuery(
         name="Raw App Data Mapping",
         description="",
@@ -36,15 +38,17 @@ def update_raw_app_data(dune: DuneAPI):
 
 
 class Environment(Enum):
-    staging = "barn"
-    production = "prod"
+    """Enum for Deployment Environments"""
+    STAGING = "barn"
+    PRODUCTION = "prod"
 
     def __str__(self) -> str:
         return self.value
 
 
 def update_parsed_app_data(dune: DuneAPI, env: Environment):
-    query_id = int(getenv("QUERY_ID_PARSED_APP_DATA"))
+    """Updates the Parsed App Data View"""
+    query_id = int(getenv("QUERY_ID_PARSED_APP_DATA", "1032466"))
     query = DuneQuery(
         name="Parsed App Data",
         description="",


### PR DESCRIPTION
Split update into two queries (since they should not be linked together).

The first updates the raw_app content (could probably also be split by environment).

The second one is split by environment using a query parameter.

Note that I also took this opportunity to rename the views (with cow_protocol instead of gp)


**Requires** an additional runtime argument as a script argument in the kubernetes config.

# Test Plan:
```
python -m dune_api_scripts.update_appdata_view --environment barn
```