### PR TITLE
[HotFix] Failing Build

### DIFF
--- a/dune_api_scripts/docker/Dockerfile.binary
+++ b/dune_api_scripts/docker/Dockerfile.binary
@@ -1,4 +1,5 @@
-FROM python:3-alpine
+FROM python:alpine
+RUN apk add --update gcc libc-dev
 WORKDIR /usr/src/app/
 COPY . ./dune_api_scripts/
 RUN cd ./dune_api_scripts && pip install -r requirements.txt


### PR DESCRIPTION
Our main branch has been failing deployment now for the past two commits. It appears to be related to the dependency bump in duneapi and likely related to new requirements introduced in such a large version bump.

The Error was the following:

```
  > [4/4] RUN cd ./dune_api_scripts && pip install -r requirements.txt:
#9 16.66   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 16.66 error: legacy-install-failure
#9 16.66 
#9 16.66 × Encountered error while trying to install package.
#9 16.66 ╰─> pycryptodome
#9 16.66 
```

and it is fixed by updating these in the docker file:
```
update gcc and libc-dev for passing build
```


## Test Plan

To reproduce the error: check out `main` and try this:

```
cd dune_api_scripts/
 docker build -f ./docker/Dockerfile.binary . 
```


To see the fix, try the same thing from this branch `update-docker-file` and see a successful build!