### PR TITLE
[Retention] exit when start > end

### DIFF
--- a/dune_api_scripts/update/user_retention.py
+++ b/dune_api_scripts/update/user_retention.py
@@ -111,6 +111,13 @@ def fetch_retention_till(
     existing_data, latest_entry = open_or_create(DUNE_DATA_DIR, "retention.csv")
 
     start = latest_entry + timedelta(days=1)
+    if start > end:
+        # This happens when the script is fully updated and latest_entry = end
+        print(
+            f"User Retention already up to date! "
+            f"Nothing to do until tomorrow {end + timedelta(days=1)}"
+        )
+        return
     missing_dates = date_range(start, end)
     print(f"Fetching Retention from {start} to {end} (yesterday)")
 


### PR DESCRIPTION
Earlier we saw in our pod logs (because I was testing and running the script every minute instead of every day like it should) that the program prints something weird when its already updated:
```
$ kubectl logs dev-dfusion-user-retention-cj-v10-27647277-sd6sw
Fetching Retention from 2022-07-26 to 2022-07-25 (yesterday)
User Retention successfully updated: https://dune.xyz/queries/1103196
```

Notice from date is greater than to date in logs.

# TODO
Also I should take this opportunity to use proper logging here.