### PR TITLE
Dune Query Instantantiation Change

### DIFF
--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from dotenv import load_dotenv
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, Network
+from duneapi.types import DuneQuery
 from duneapi.util import open_query
 
 if __name__ == "__main__":

--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     query_id = int(os.getenv("QUERY_ID_ALL_APP_DATA", "142824"))
     query = open_query("./dune_api_scripts/queries/all_app_data.sql")
     time_of_request = int(time.time())
-    dune_query = DuneQuery("", "", query, Network.MAINNET, [], query_id)
+    dune_query = DuneQuery(query_id)
 
     # fetch query result
     app_data = dune.fetch(dune_query)

--- a/dune_api_scripts/store_query_result_all_distinct_app_data.py
+++ b/dune_api_scripts/store_query_result_all_distinct_app_data.py
@@ -19,10 +19,11 @@ if __name__ == "__main__":
     dune = DuneAPI.new_from_environment()
 
     # fetch query result id using query id
-    query_id = int(os.getenv("QUERY_ID_ALL_APP_DATA", "142824"))
-    query = open_query("./dune_api_scripts/queries/all_app_data.sql")
     time_of_request = int(time.time())
-    dune_query = DuneQuery(query_id)
+    dune_query = DuneQuery(
+        query_id=int(os.getenv("QUERY_ID_ALL_APP_DATA", "142824")),
+        raw_sql=open_query("./dune_api_scripts/queries/all_app_data.sql")
+    )
 
     # fetch query result
     app_data = dune.fetch(dune_query)

--- a/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     QUERY = build_query_for_all_trading_data()
     query_id = int(os.getenv("QUERY_ID_ENTIRE_HISTORY_TRADING_DATA", "157348"))
     time_of_request = int(time.time())
-    dune_query = DuneQuery("", "", QUERY, Network.MAINNET, [], query_id)
+    dune_query = DuneQuery(query_id)
 
     # fetch data
     data = dune.fetch(dune_query)

--- a/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
@@ -9,7 +9,7 @@ import os
 import time
 import datetime
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, Network
+from duneapi.types import DuneQuery
 from dotenv import load_dotenv
 
 from .queries import build_query_for_affiliate_data

--- a/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_entire_history_trading_data.py
@@ -37,10 +37,11 @@ if __name__ == "__main__":
     dune = DuneAPI.new_from_environment()
 
     # build query
-    QUERY = build_query_for_all_trading_data()
-    query_id = int(os.getenv("QUERY_ID_ENTIRE_HISTORY_TRADING_DATA", "157348"))
     time_of_request = int(time.time())
-    dune_query = DuneQuery(query_id)
+    dune_query = DuneQuery(
+        query_id=int(os.getenv("QUERY_ID_ENTIRE_HISTORY_TRADING_DATA", "157348")),
+        raw_sql=build_query_for_all_trading_data()
+    )
 
     # fetch data
     data = dune.fetch(dune_query)

--- a/dune_api_scripts/store_query_result_for_todays_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_todays_trading_data.py
@@ -33,10 +33,11 @@ if __name__ == "__main__":
     # initialize the environment
     dune = DuneAPI.new_from_environment()
 
-    query_id = int(os.getenv("QUERY_ID_TODAYS_TRADING_DATA", "249240"))
-    QUERY = build_query_for_todays_trading_volume()
     time_of_request = int(time.time())
-    dune_query = DuneQuery(query_id)
+    dune_query = DuneQuery(
+        query_id=int(os.getenv("QUERY_ID_TODAYS_TRADING_DATA", "249240")),
+        raw_sql=build_query_for_todays_trading_volume()
+    )
     # fetch data
     data = dune.fetch(dune_query)
     data_set = {"user_data": data, "time_of_download": time_of_request}

--- a/dune_api_scripts/store_query_result_for_todays_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_todays_trading_data.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     query_id = int(os.getenv("QUERY_ID_TODAYS_TRADING_DATA", "249240"))
     QUERY = build_query_for_todays_trading_volume()
     time_of_request = int(time.time())
-    dune_query = DuneQuery("", "", QUERY, Network.MAINNET, [], query_id)
+    dune_query = DuneQuery(query_id)
     # fetch data
     data = dune.fetch(dune_query)
     data_set = {"user_data": data, "time_of_download": time_of_request}

--- a/dune_api_scripts/store_query_result_for_todays_trading_data.py
+++ b/dune_api_scripts/store_query_result_for_todays_trading_data.py
@@ -7,7 +7,7 @@ import datetime
 import os
 import time
 from duneapi.api import DuneAPI
-from duneapi.types import DuneQuery, Network
+from duneapi.types import DuneQuery
 from dotenv import load_dotenv
 
 from .utils import store_as_json_file


### PR DESCRIPTION
Due to recent changes in the Dune API, the parameters provided to instantiate a Dune query have been simplified.

The error we were seeing was due to a lack of explicit parameter names.

I will be adding a follow up PR to introduce type checking (this is what would have caught this issue). however, I didn't want to introduce it here, because it would make the PR far too bulky and had to read.