### PR TITLE
[Dune Sync] Populate Full App Data

### DIFF
--- a/pysrc/main.py
+++ b/pysrc/main.py
@@ -1,10 +1,50 @@
 """Main Entry point for app_hash sync"""
 import asyncio
+import logging.config
 import os
 
 from dotenv import load_dotenv
+from dune_client.types import DuneRecord
 
 from pysrc.fetch.dune import DuneFetcher
+from pysrc.fetch.ipfs import Cid
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
+log.setLevel(logging.DEBUG)
+
+
+def fetch_and_filter(
+    dune_results: list[DuneRecord],
+    max_retries: int = 3,
+) -> tuple[list[DuneRecord], list[DuneRecord]]:
+    """
+    Run loop fetching app_data for hashes,
+    separates into (found and not found), returning the pair.
+    """
+    found: list[dict[str, str]] = []
+    not_found: list[dict[str, str]] = []
+    # Drain the dune_results into "found" and "not found" categories
+    while dune_results:
+        row = dune_results.pop()
+        app_hash = row["app_hash"]
+        cid = Cid(app_hash)
+        app_data = cid.get_content(max_retries)
+
+        # Here it would be nice if python we more like rust!
+        if app_data is not None:
+            # Row is modified and added found items
+            log.debug(f"Found content for {row['app_hash']} at CID {cid}")
+            row["content"] = app_data
+            found.append(row)
+        else:
+            # Unmodified row added to not_found items
+            log.debug(
+                f"No content found for {row['app_hash']} at CID {cid} after {max_retries} retries"
+            )
+            not_found.append(row)
+
+    return found, not_found
 
 
 async def main(dune: DuneFetcher) -> None:
@@ -13,12 +53,22 @@ async def main(dune: DuneFetcher) -> None:
     fname, column = "sync_block", "last_synced_block"
     block_range = await dune.app_hash_block_range(fname, column)
 
-    hash_data = await dune.get_app_hashes(block_range)
-    # TODO - fetch AppContent from here before write.
+    dune_results = await dune.get_app_hashes(block_range)
+
+    # TODO - although it is unlikely we will ever "cold-start",
+    #  it seems that storing all this data in memory could be problematic
+    #  e.g. program fails and all progress is lost, etc...
+    #  It might be nice to append the results directly to the stream as they are found.
+    #  I am going to implement append anyway (for the missing records)
+    found, not_found = fetch_and_filter(dune_results)
 
     # Write the most recent data and also record the block_from,
     # so that next run will know where to start
-    dune.file_manager.write_ndjson(hash_data, f"app_hashes_{block_range.block_to}")
+    dune.file_manager.write_ndjson(found, f"app_hashes_{block_range.block_to}")
+    # TODO - "append" missing to an existing file.
+    dune.file_manager.write_ndjson(
+        not_found, f"missing_app_hashes_{block_range.block_to}"
+    )
     # Write last sync block only after the data has been written.
     dune.file_manager.write_csv([{column: str(block_range.block_to)}], fname)
 


### PR DESCRIPTION
This takes the results of the app_hash fetching and proceeds in getting the corresponding IPFS content. 

While fetching it separates it into two pieces `found` and `not_found`. I ran this once and it took 58 minutes for 2310 records (this is our "seed data") - attached here:


## Output
Among 2310 total app hashes, only 40 we "not found" (and I suspect they were Null). You can find them all in the attached zip file.

[data.zip](https://github.com/cowprotocol/dune-bridge/files/10033070/data.zip) -- Full content ~172Kb


## Logs

Here is a snippet of the logs (in case we want to add something) -- like "content successfully written to... since it appears to be missing"

<details><summary>Logs From Single Run</summary>

```
2022-11-17 15:42:00,637 INFO dune_client.file creating write path /dune-bridge/data
2022-11-17 15:42:00,638 WARNING pysrc.fetch.dune block range file sync_block.csv not found, using genesis block 12153262
2022-11-17 15:42:00,638 DEBUG pysrc.fetch.dune Executing Query(query_id=1615490, name='Latest Possible App Hash Block', params=None)
2022-11-17 15:42:00,960 INFO dune_client.base_client waiting for query execution 01GJ30M7GNR48JTXFR44241G8P to complete: ExecutionState.EXECUTING
2022-11-17 15:42:11,243 DEBUG pysrc.fetch.dune Got 1 results for execution 01GJ30M7GNR48JTXFR44241G8P
2022-11-17 15:42:11,243 DEBUG pysrc.fetch.dune Executing Query(query_id=1610025, name='Unique App Hashes', params=[<dune_client.types.QueryParameter object at 0x1078d2140>, <dune_client.types.QueryParameter object at 0x1078d2ad0>])
2022-11-17 15:42:11,562 INFO dune_client.base_client waiting for query execution 01GJ30MHV0R9E6J5094VKZXPBP to complete: ExecutionState.EXECUTING
2022-11-17 15:42:22,019 DEBUG pysrc.fetch.dune Got 2310 results for execution 01GJ30MHV0R9E6J5094VKZXPBP
2022-11-17 15:42:23,866 DEBUG __main__ Found content for 0xd68a5c78d920efc8e8c4785baadb0d9c64d21ea88c22592631d6135fdba6fa94 at CID bafybeigwrjohrwja57eorrdylovnwdm4mtjb5kemejmsmmowcnp5xjx2sq
2022-11-17 15:42:24,778 DEBUG __main__ Found content for 0x2757c919984771aaf288c738f6507886b9e218baeb199bbe6639c707742868ee at CID bafybeibhk7ertgchogvpfcghhd3fa6egxhrbroxldgn34zrzy4dxikdi5y
2022-11-17 15:42:25,597 DEBUG __main__ Found content for 0xc80a7dcd584a25427ae0cddc53558076c156331a29e666a45cd6cef9867239cd at CID bafybeigibj642wckevbhvygn3rjvladwyfldggrj4ztkixgwz34ym4rzzu
2022-11-17 15:46:36,757 DEBUG __main__ No content found for 0x1487f733547707805dc8bb4b738f97b098bd793d8065934efdf9eb45de5f45e1 at CID bafybeiauq73tgvdxa6af3sf3jnzy7f5qtc6xspmamwju57pz5nc54x2f4e after 3 retries
2022-11-17 15:46:31,966 DEBUG __main__ Found content for 0xe24b3b0af075daa388fd153b526c2fc8204a00d5671fb95fdbc3484d82bf4e65 at CID bafybeihcjm5qv4dv3kryr7ivhnjgyl6iebfabvlhd64v7w6djbgyfp2omu
2022-11-17 15:46:32,954 DEBUG __main__ Found content for 0xa687e0633ad964efaac51f6ca6064bf23447beb2238dc89eae7c98283ce3cf2f at CID bafybeifgq7qggowzmtx2vri7nstams7sgrd35mrdrxej5lt4taudzy6pf4
...
```

</details>


## Follow ups

There are a few nice "todos" left in this code, but I think we might actually be ready with this as is.

To summarize some follow up tasks:
- [x] append missing records to an already existing `missing_content` file (so that when we decide to try again they are all in one place. This will need to be implemented in dune-client side. Append can also be used to write as content is found instead of storing all results in memory. This is not a HUGE issue, because this seed data will make up for 99% of the long running scripts. All future runs are expected to complete in seconds. This is already a recorded issue in dune-client: https://github.com/cowprotocol/dune-client/issues/37

- [ ] consider recording the number of timeouts and possibly removing this "max retries" loop on the content fetching. I sincerely suspect that all found app content was found on the first attempt and all not found content does not exist.

- [ ] Post Results to Dune!


