### PR TITLE
Implement AppData Spec v0.5.0

### DIFF
--- a/src/models/app_data_json_format.rs
+++ b/src/models/app_data_json_format.rs
@@ -230,7 +230,6 @@ mod tests {
             "appCode": "MooSwap",
             "environment": "production",
             "metadata": {
-                "environment": "production",
                 "referrer":{
                     "version": "0.1.0",
                     "address": "0x8c35B7eE520277D14af5F6098835A584C337311b",

--- a/src/models/referral_store.rs
+++ b/src/models/referral_store.rs
@@ -51,7 +51,7 @@ impl Serialize for AppDataStruct {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::app_data_json_format::{Metadata, Referrer};
+    use crate::models::app_data_json_format::{Metadata, Referrer, ReferrerV1, Version};
     use serde_json;
     use serde_json::json;
 
@@ -64,42 +64,40 @@ mod tests {
             .parse()
             .unwrap();
         let entry = AppData {
-            version: "1.2.3".to_string(),
+            version: Version::V1,
             app_code: "MooSwap".to_string(),
-            environment: None,
             metadata: Some(Metadata {
-                environment: Some("production".to_string()),
-                referrer: Some(Referrer {
+                referrer: Some(Referrer::V1(ReferrerV1 {
                     // Note that serialization turns everything to lowercase...
                     address: "0x8c35b7ee520277d14af5f6098835a584c337311b"
                         .parse()
                         .unwrap(),
-                    version: "6.6.6".to_string(),
-                }),
-                quote: None,
+                })),
+                ..Default::default()
             }),
+            ..Default::default()
         };
 
         app_data_struct
             .app_data
             .insert(key, AppDataEntry::Data(Some(entry)));
 
-        let expected_serialization = json!(
-        {
-            "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4":{
-                 "version":"1.2.3",
-                 "appCode":"MooSwap",
-                 "environment": null,
-                 "metadata":{
-                     "environment": "production",
-                     "referrer":{
-                         "address":"0x8c35b7ee520277d14af5f6098835a584c337311b",
-                         "version":"6.6.6"
-                 },
-                 "quote": null,
-            }
-         }
+        let expected_serialization = json!({
+            "0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4": {
+                "version": "0.1.0",
+                "appCode": "MooSwap",
+                "environment": null,
+                "metadata": {
+                    "referrer": {
+                        "version":"0.1.0",
+                        "address":"0x8c35b7ee520277d14af5f6098835a584c337311b",
+                    },
+                    "quote": null,
+                    "class": null,
+                },
+            },
         });
+
         assert_eq!(
             serde_json::to_value(&app_data_struct).unwrap(),
             expected_serialization

--- a/src/referral_maintenance.rs
+++ b/src/referral_maintenance.rs
@@ -244,7 +244,7 @@ fn get_cid_from_app_data(hash: H256) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::app_data_json_format::{Metadata, Referrer};
+    use crate::models::app_data_json_format::{Metadata, Referrer, ReferrerV1, Version};
     use serde_json::json;
 
     #[test]
@@ -295,19 +295,17 @@ mod tests {
         .await
         .unwrap();
         let expected = AppData {
-            version: "0.1.0".to_string(),
+            version: Version::V1,
             app_code: "CowSwap".to_string(),
-            environment: None,
             metadata: Some(Metadata {
-                environment: None,
-                referrer: Some(Referrer {
+                referrer: Some(Referrer::V1(ReferrerV1 {
                     address: "0x424a46612794dbb8000194937834250dc723ffa5"
                         .parse()
                         .unwrap(),
-                    version: "0.1.0".to_string(),
-                }),
-                quote: None,
+                })),
+                ..Default::default()
             }),
+            ..Default::default()
         };
         assert_eq!(referral, expected);
     }


### PR DESCRIPTION
This PR implements the new AppData spec described in https://github.com/cowprotocol/cowswap/issues/1542. Specifically, this adds a new `class` field to the `Metadata` type for including information on the order class (either `market`, `limit` or `liquidity` order).

I also added a few unrelated changes (can split into a separate PR if necessary, but they were in related code). Namely:
- Remove `environment` from `Metadata`, according to https://github.com/cowprotocol/app-data, it was never there in the first place
- Stricter version parsing

### Test Plan

Added new unit tests to test serialization. Other than that, no real logic changes to test.